### PR TITLE
Fix basePath example

### DIFF
--- a/src/pages/docs/configuration.md
+++ b/src/pages/docs/configuration.md
@@ -45,9 +45,7 @@ Example:
 
 ```text/javascript
 module.exports = {
-	basePath: {
-		branch: '/base-path'
-	}
+	basePath: '/base-path'
 };
 ```
 
@@ -69,9 +67,7 @@ require the following config.
 
 ```text/javascript
 module.exports = {
-	basePath: {
-		branch: '/project-name'
-	},
+	basePath: '/project-name',
 	deployOptions: {
 		branch: 'gh-pages'
 	}


### PR DESCRIPTION
`basePath` should be a string, I had problems using the object transforming. It transform the url to `/[Object object]`. Also, the documentation says that `basePath` should be a string.